### PR TITLE
refactor(auth): 소셜 로그인 로직을 클라이언트 주도형 흐름으로 리팩토링

### DIFF
--- a/pet_project_backend/app/api/auth/routes.py
+++ b/pet_project_backend/app/api/auth/routes.py
@@ -1,56 +1,68 @@
-from flask import Blueprint, request, jsonify, redirect, current_app
-from google_auth_oauthlib.flow import Flow
+from flask import Blueprint, request, jsonify, current_app
 from google.oauth2 import id_token
 from google.auth.transport import requests as google_requests
+from google_auth_oauthlib.flow import Flow
 import os
 
 from . import services as auth_services
 from app.core.security import create_access_token, create_refresh_token
+from app.schemas.user_schema import UserSchema
 
 auth_bp = Blueprint('auth', __name__)
+user_schema = UserSchema()
 
-def get_google_flow():
-    client_secrets_file = current_app.config['GOOGLE_CLIENT_SECRETS_PATH']
-    if not os.path.exists(client_secrets_file):
-        raise FileNotFoundError(f"Google client secrets file not found at: {client_secrets_file}")
+@auth_bp.route('/social', methods=['POST'])
+def social_login():
+    """
+    클라이언트(앱)로부터 받은 소셜 인증 코드를 검증하고,
+    로그인 또는 회원가입 처리 후 JWT 토큰을 발급합니다.
+    """
+    data = request.get_json()
+    provider = data.get('provider')
+    auth_code = data.get('auth_code')
 
-    return Flow.from_client_secrets_file(
-        client_secrets_file=client_secrets_file,
-        scopes=[
-            "https://www.googleapis.com/auth/userinfo.profile",
-            "https://www.googleapis.com/auth/userinfo.email",
-            "openid"
-        ]
-    )
+    if not provider or not auth_code:
+        return jsonify({"error_code": "INVALID_INPUT", "message": "Provider and auth code are required."}), 400
 
-@auth_bp.route('/login/google')
-def google_login():
-    flow = get_google_flow()
-    authorization_url, state = flow.authorization_url(access_type='offline', include_granted_scopes='true')
-    return redirect(authorization_url)
+    if provider == 'google':
+        try:
+            client_secrets_file = current_app.config['GOOGLE_CLIENT_SECRETS_PATH']
+            if not os.path.exists(client_secrets_file):
+                 raise FileNotFoundError("Google client secrets file not found.")
 
-@auth_bp.route('/login/google/callback')
-def google_callback():
-    flow = get_google_flow()
-    try:
-        flow.fetch_token(authorization_response=request.url)
-        credentials = flow.credentials
-        
-        id_info = id_token.verify_oauth2_token(
-            credentials.id_token, google_requests.Request(), credentials.client_id)
+            # 앱(클라이언트)에서 전달된 인증 코드를 토큰으로 교환합니다.
+            flow = Flow.from_client_secrets_file(
+                client_secrets_file=client_secrets_file,
+                scopes=None,
+                redirect_uri='postmessage' # 모바일/웹 클라이언트용 코드 교환 시 사용
+            )
+            flow.fetch_token(code=auth_code)
+            credentials = flow.credentials
+            
+            # 발급받은 ID 토큰을 검증하여 사용자 정보를 가져옵니다.
+            id_info = id_token.verify_oauth2_token(
+                credentials.id_token, 
+                google_requests.Request(), 
+                credentials.client_id
+            )
 
-        user = auth_services.get_or_create_user_from_google(id_info)
+            # 서비스 계층을 호출하여 사용자를 DB에서 찾거나 생성합니다.
+            user, is_new_user = auth_services.get_or_create_user_from_google(id_info)
 
-        jwt_payload = {'user_id': user.id, 'email': user.email}
-        access_token = create_access_token(data=jwt_payload)
-        refresh_token = create_refresh_token(data=jwt_payload)
-        
-        return jsonify({
-            "message": "Login successful",
-            "access_token": access_token,
-            "refresh_token": refresh_token
-        }), 200
+            # 서비스 전용 JWT를 생성합니다.
+            jwt_payload = {'user_id': user.id, 'email': user.email}
+            access_token = create_access_token(data=jwt_payload)
+            refresh_token = create_refresh_token(data=jwt_payload)
+            
+            return jsonify({
+                "access_token": access_token,
+                "refresh_token": refresh_token,
+                "is_new_user": is_new_user
+            }), 200
 
-    except Exception as e:
-        print(f"An error occurred: {e}")
-        return jsonify({"error": "Authentication failed"}), 401
+        except Exception as e:
+            # 프로덕션 환경에서는 상세 에러를 로그로 남기는 것이 좋습니다.
+            print(f"An error occurred during Google authentication: {e}")
+            return jsonify({"error_code": "AUTHENTICATION_FAILED", "message": "Google authentication failed."}), 401
+    
+    return jsonify({"error_code": "UNSUPPORTED_PROVIDER", "message": "Unsupported provider."}), 400

--- a/pet_project_backend/app/api/auth/services.py
+++ b/pet_project_backend/app/api/auth/services.py
@@ -3,54 +3,47 @@ from app.models.user import User
 
 db = firestore.client()
 
-def get_or_create_user_from_google(id_info: dict) -> User:
+def get_or_create_user_from_google(id_info: dict) -> tuple[User, bool]:
     """
     Google 사용자 정보로 Firestore에서 사용자를 찾거나 생성합니다.
-    
+
     Args:
-        id_info: Google id_token.verify_oauth2_token()을 통해 받은 사용자 정보 딕셔너리.
+        id_info: Google id_token.verify_oauth2_token()을 통해 받은 사용자 정보.
 
     Returns:
-        생성되거나 조회된 User 데이터 클래스 인스턴스.
+        A tuple containing:
+        - User: The created or retrieved User dataclass instance.
+        - bool: True if the user was newly created, False otherwise.
     """
     users_ref = db.collection('users')
-    google_id = id_info.get('sub') # 'sub'는 Google의 고유 사용자 ID입니다.
+    google_id = id_info.get('sub') # Google의 고유 사용자 ID
+    user_email = id_info.get('email')
 
-    # 1. google_id로 기존 사용자 조회
-    docs = users_ref.where('google_id', '==', google_id).limit(1).stream()
-    existing_user_doc = next(docs, None)
+    # google_id로 기존 사용자 조회
+    query = users_ref.where('google_id', '==', google_id).limit(1)
+    results = query.stream()
+    existing_user_doc = next(results, None)
 
     if existing_user_doc:
-        # 2. 사용자가 존재하면 User 객체로 변환하여 반환
+        # 사용자가 존재하면 User 객체로 변환하여 반환
         user_data = existing_user_doc.to_dict()
-        user = User(
-            id=existing_user_doc.id,
-            google_id=user_data.get('google_id'),
-            email=user_data.get('email'),
-            name=user_data.get('name'),
-            picture=user_data.get('picture'),
-            created_at=user_data.get('created_at')
-        )
-        return user
+        user = User(id=existing_user_doc.id, **user_data)
+        return user, False # (기존 유저, is_new_user=False)
     else:
-        # 3. 사용자가 없으면 새로 생성
+        # 사용자가 없으면 새로 생성
         new_user_data = {
             'google_id': google_id,
-            'email': id_info.get('email'),
+            'email': user_email,
             'name': id_info.get('name'),
             'picture': id_info.get('picture'),
-            'created_at': firestore.SERVER_TIMESTAMP, # 서버 시간으로 기록
+            'created_at': firestore.SERVER_TIMESTAMP,
         }
         
         # Firestore에 새 사용자 문서 추가
         update_time, new_user_ref = users_ref.add(new_user_data)
         
-        # 4. 생성된 사용자 정보를 User 객체로 변환하여 반환
-        created_user = User(
-            id=new_user_ref.id,
-            **new_user_data
-        )
-        # created_at 필드는 서버에서 생성되므로 None으로 남겨둘 수 있습니다.
-        # 필요하다면 new_user_ref.get()으로 다시 조회하여 채울 수 있습니다.
-        created_user.created_at = None 
-        return created_user
+        # 생성된 사용자 정보를 User 객체로 변환하여 반환
+        created_user_data = new_user_ref.get().to_dict()
+        created_user = User(id=new_user_ref.id, **created_user_data)
+
+        return created_user, True # (신규 유저, is_new_user=True)


### PR DESCRIPTION
### **변경 내용**

-   Google OAuth 로그인 로직을 서버 주도형에서 클라이언트 주도형 흐름으로 리팩토링했습니다.
-   기존 `/login/google` 및 `/login/google/callback` 엔드포인트를 삭제하고, `POST /api/auth/social` 엔드포인트를 명세서 대로 추가했습니다.

### **변경 사유**

-   모바일 클라이언트 환경의 표준 인증 방식에 맞추기 위함입니다. (원래는 웹 애플리케이션 형태였음)

### **테스트(완)** 
- 실제 테스트 해보실거면 pet_project_backend\app\api\auth\routes.py 37번줄을 변경
 ```
 redirect_uri="https://developers.google.com/oauthplayground" #테스트용
 ```
<img width="868" height="625" alt="image" src="https://github.com/user-attachments/assets/851cdb82-bbbf-4606-ae93-d47d9356a277" />
